### PR TITLE
Reverse the platform ordering in colorbar to show correct ordering.

### DIFF
--- a/metrics/scripts/pp_vis.py
+++ b/metrics/scripts/pp_vis.py
@@ -167,10 +167,10 @@ class akde:
 def pp_cdf_raw_effs(theapp):
     """Returns sorted subsequences and harmonic means of same."""
     valid_effs = [x for x in theapp if x[1] > 0 and x[1] != float("inf")]
-    sorted_effs = sorted(valid_effs, key=lambda x: x[1])
+    sorted_effs = sorted(valid_effs, key=lambda x: x[1], reverse=True)
     res = []
     for i in range(len(sorted_effs)):
-        res.append((sorted_effs[i][1], harmean([x[1] for x in sorted_effs[i:]]), sorted_effs[i][0]))
+        res.append((sorted_effs[i][1], harmean([x[1] for x in sorted_effs[:i+1]]), sorted_effs[i][0]))
     return res
 
 
@@ -309,10 +309,10 @@ def plot_cascade(fig,
 
         effs, pps, plats = zip(*cascade)
 
-        ppl = list(enumerate(reversed(pps), 1))
+        ppl = list(enumerate(pps, 1))
         ppl = ppl + [(ppl[-1][0], 0.0)]
         data_pp = np.asarray(ppl)
-        effl = list(enumerate(reversed(effs), 1))
+        effl = list(enumerate(effs, 1))
         effl = effl + [(effl[-1][0], 0.0)]
         data_eff = np.asarray(effl)
 


### PR DESCRIPTION
The cascade plot color bar for the platforms is currently in the
reverse order to the efficiencies plotted above. For example,
the Platform 1 is shown on as the left-most point on the line
but the right-most color in the color box.

The mapping of platforms to color is correct. So this commit just
flips the plotting so that it matches up.

For the synthetic data, consider the multi-target application, with the green lines. A, C, E, G are all 100% efficiency, and form the first 4 points in the lines. However, A is the darkest green but appears under Platform 6, where the efficiency is 0.

<img width="487" alt="Screenshot 2021-03-31 at 15 57 50" src="https://user-images.githubusercontent.com/1379598/113165728-10a5ec80-923a-11eb-8c8c-5e0aa9dd84ef.png">

With this fix, the synthetic graph looks like this:
![synthetic_cascade](https://user-images.githubusercontent.com/1379598/113165773-1996be00-923a-11eb-835b-d711138105ef.png)


The orange single-target application also shows this well. A has 100% efficiency and B-J all have 10%. Platform A is shown by Platform 10 instead of Platform 1.
